### PR TITLE
feat: Add finally() to handleSearchButtonClick for consistent loader behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,11 +151,11 @@ function handleSearchButtonClick() {
             fetch(`https://www.omdbapi.com/?apikey=5f66aad6&s=${movieTitle}`)
               .then((response) => response.json())
               .then((data) => {
-                renderSearchResults(data.Search);
+                renderSearchResults(data.Search)
                 loader.style.display = "none"
               })
               .catch((error) => {
-                console.error(error);
+                console.error(error)
                 loader.style.display = "none"
               })
               .finally(() => {

--- a/index.js
+++ b/index.js
@@ -152,15 +152,15 @@ function handleSearchButtonClick() {
               .then((response) => response.json())
               .then((data) => {
                 renderSearchResults(data.Search);
-                loader.style.display = "none";
+                loader.style.display = "none"
               })
               .catch((error) => {
                 console.error(error);
-                loader.style.display = "none";
+                loader.style.display = "none"
               })
               .finally(() => {
-                loader.style.display = "none";
-              });
+                loader.style.display = "none"
+              })
     }
         }
 }

--- a/index.js
+++ b/index.js
@@ -149,15 +149,18 @@ function handleSearchButtonClick() {
             const movieTitle = inputMovie.value
 
             fetch(`https://www.omdbapi.com/?apikey=5f66aad6&s=${movieTitle}`)
-                .then(response => response.json())
-                .then(data => {
-                    renderSearchResults(data.Search)
-                    loader.style.display = "none"
-            } )
-            .catch((error) => {
-                console.error(error)
-                loader.style.display = "none"
-            })
+              .then((response) => response.json())
+              .then((data) => {
+                renderSearchResults(data.Search);
+                loader.style.display = "none";
+              })
+              .catch((error) => {
+                console.error(error);
+                loader.style.display = "none";
+              })
+              .finally(() => {
+                loader.style.display = "none";
+              });
     }
         }
 }


### PR DESCRIPTION
## Description

Introduced `.finally()` to hide the loader after the search results are rendered, regardless of whether the fetch operation was successful or not.

The loader will be hidden after the search results are rendered, regardless of whether the fetch operation was successful or not. This ensures that the loader is always hidden, even if an error occurs.